### PR TITLE
removed FlashInfer lib

### DIFF
--- a/README_DeepSeekR1.md
+++ b/README_DeepSeekR1.md
@@ -82,9 +82,6 @@ By following the instructions below, one should be able to set up a server runni
     pip install -r requirements.txt
     ```
 
-> [!NOTE]  
-> Since the FlashInfer library ([GitHub](https://github.com/flashinfer-ai/flashinfer)) is used, a specific version of vLLM that is compatible with Torch 2.6.0 (CUDA 12.4) is installed.
-
 1. Set parameters in the SLURM scripts (H100 or H200 GPUs).
   
     Find the SLURM scripts in the `server/` directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,3 @@ torchaudio==2.6.0
 
 # vLLM
 vllm==0.8.5.post1
-
-# FlashInfer
---extra-index-url https://flashinfer.ai/whl/cu124/torch2.6/
-flashinfer-python


### PR DESCRIPTION
Removed FlashInfer to benefit from vLLM default FlashAttention backend. Also recent cluster upgrade creates pip install issues with FlashInfer. closes #17. 

Only one reviewer is needed, and will merge after first approval. 