### PR TITLE
Bump vllm 0.9.0 and torch 2.8.0 to close Dependabot advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-# PyTorch 2.6 + CUDA 12.4
+# PyTorch 2.8 + CUDA 12.4
 --extra-index-url https://download.pytorch.org/whl/cu124
-torch==2.6.0
-torchvision==0.21.0
-torchaudio==2.6.0
+torch==2.8.0
+torchvision==0.23.0
+torchaudio==2.8.0
 
 # vLLM
-vllm==0.8.5.post1
+vllm==0.9.0


### PR DESCRIPTION
Closes 13 open Dependabot advisories, including two critical RCE in vllm (CVE-2025-47277 PyNcclPipe, CVE-2025-32444 Mooncake).

Changes:
- vllm 0.8.5.post1 -> 0.9.0
- torch 2.6.0 -> 2.8.0
- torchvision 0.21.0 -> 0.23.0
- torchaudio 2.6.0 -> 2.8.0

Closes #36.